### PR TITLE
Support legacy default values for missing license field in package metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ This change log follows the conventions of [keepachangelog.com](http://keepachan
 
 ## [Unreleased]
 ### Fixed
-- Nothing here yet
+- Support legacy default values for missing license field in package metadata ([#47](https://github.com/pilosus/pip-license-checker/issues/47))
 
 ## [0.14.0] - 2021-07-10
 ### Fixed

--- a/src/pip_license_checker/pypi.clj
+++ b/src/pip_license_checker/pypi.clj
@@ -37,6 +37,8 @@
 
 (def license-data-error {:name license-name-error :desc license-desc-error})
 
+(def license-undefined #{"" "UNKNOWN" [] ["UNKNOWN"]})
+
 (def regex-match-classifier #"License :: .*")
 (def regex-split-classifier #" :: ")
 
@@ -192,7 +194,7 @@
   [data]
   (let [info (get data "info")
         {:strs [license classifiers home_page]} info
-        license-license (if (= "" license) nil license)
+        license-license (if (contains? license-undefined license) nil license)
         classifiers-license (classifiers->license classifiers)
         license-name (or
                       classifiers-license

--- a/test/pip_license_checker/pypi_test.clj
+++ b/test/pip_license_checker/pypi_test.clj
@@ -176,6 +176,24 @@
     "BSD"
     {:name "BSD", :desc "Permissive"}
     "Get from GitHub API"]
+   [{"info"
+     {"license" "UNKNOWN"
+      "classifiers" []}}
+    "MIT"
+    {:name "MIT", :desc "Permissive"}
+    "Get from GitHub API for older metadata format for missing license field - UNKNOWN string"]
+   [{"info"
+     {"license" []
+      "classifiers" []}}
+    "MIT"
+    {:name "MIT", :desc "Permissive"}
+    "Get from GitHub API for older metadata format for missing license field - empty list"]
+   [{"info"
+     {"license" ["UNKNOWN"]
+      "classifiers" []}}
+    "MIT"
+    {:name "MIT", :desc "Permissive"}
+    "Get from GitHub API for older metadata format for missing license field - list with UNKNOWN"]
    [{"wut" 123}
     nil
     pypi/license-data-error


### PR DESCRIPTION
Close #47 