### PR TITLE
fails-only flag to filter only packages with license types matching -provided with --fail flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This change log follows the conventions of [keepachangelog.com](http://keepachan
 ## [Unreleased]
 ### Fixed
 
+## [0.17.0] - 2021-07-18
+### Added
+- Flag `--fails-only` to print only licenses found for `--fail` flags ([#57](https://github.com/pilosus/pip-license-checker/issues/57))
+
 ## [0.16.0] - 2021-07-15
 ### Added
 - Show all licenses if more than one classifier specified ([#52](https://github.com/pilosus/pip-license-checker/issues/52))

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Description:
   -t, --[no-]with-totals                    Print totals for license types
   -o, --[no-]totals-only                    Print only totals for license types
   -d, --[no-]table-headers                  Print table headers
+  -m, --[no-]fails-only                     Print only packages of license types specified with --fail flags
   -h, --help                                Print this help message
 
 Examples:

--- a/src/pip_license_checker/spec.clj
+++ b/src/pip_license_checker/spec.clj
@@ -121,7 +121,9 @@
    :requirement (s/cat
                  :name ::requirement
                  :version ::version-str)
-   :license string?))
+   :license (s/cat
+             :name string?
+             :desc string?)))
 
 
 ;; CLI

--- a/test/pip_license_checker/core_test.clj
+++ b/test/pip_license_checker/core_test.clj
@@ -21,7 +21,8 @@
                :pre false
                :with-totals false
                :totals-only false
-               :table-headers false}}
+               :table-headers false
+               :fails-only false}}
     "Normal run"]])
 
 (deftest ^:cli ^:default
@@ -68,6 +69,63 @@
            (= expected
               (vec (core/get-parsed-requiements
                     packages requirements options)))))))))
+
+(def params-filter-parsed-requirements
+  [[[{:ok? true,
+      :requirement {:name "aiohttp", :version "3.7.2"},
+      :license {:name "MIT License", :desc "Permissive"}}
+     {:ok? true,
+      :requirement {:name "aiostream", :version "0.1.0"},
+      :license {:name "GPLv3", :desc "Copyleft"}}]
+    {:fail #{"Copyleft"} :fails-only true}
+    [{:ok? true,
+      :requirement {:name "aiostream", :version "0.1.0"},
+      :license {:name "GPLv3", :desc "Copyleft"}}]
+    "Filter copyleft licenses"]
+   [[]
+    {:fail #{"Copyleft"} :fails-only true}
+    []
+    "Filter empty sequence"]
+   [[]
+    {:fail #{"Copyleft"} :fails-only true}
+    []
+    "Filter nil sequence"]
+   [[{:ok? true,
+      :requirement {:name "aiohttp", :version "3.7.2"},
+      :license {:name "MIT License", :desc "Permissive"}}
+     {:ok? true,
+      :requirement {:name "aiostream", :version "0.1.0"},
+      :license {:name "GPLv3", :desc "Copyleft"}}]
+    {:fail #{"Copyleft"} :fails-only false}
+    [{:ok? true,
+      :requirement {:name "aiohttp", :version "3.7.2"},
+      :license {:name "MIT License", :desc "Permissive"}}
+     {:ok? true,
+      :requirement {:name "aiostream", :version "0.1.0"},
+      :license {:name "GPLv3", :desc "Copyleft"}}]
+    "fails-only flag is off, do not filter"]
+   [[{:ok? true,
+      :requirement {:name "aiohttp", :version "3.7.2"},
+      :license {:name "MIT License", :desc "Permissive"}}
+     {:ok? true,
+      :requirement {:name "aiostream", :version "0.1.0"},
+      :license {:name "GPLv3", :desc "Copyleft"}}]
+    {:fail #{} :fails-only true}
+    [{:ok? true,
+      :requirement {:name "aiohttp", :version "3.7.2"},
+      :license {:name "MIT License", :desc "Permissive"}}
+     {:ok? true,
+      :requirement {:name "aiostream", :version "0.1.0"},
+      :license {:name "GPLv3", :desc "Copyleft"}}]
+    "fail flag omitted, do not filter"]])
+
+(deftest ^:integration ^:request
+  test-filter-parsed-requirements
+  (testing "Integration testing for filtering parsed requirements"
+    (doseq [[licenses options expected description]
+            params-filter-parsed-requirements]
+      (testing description
+        (is (= expected (core/filter-parsed-requirements licenses options)))))))
 
 (def params-get-license-type-totals
   [[[] {} "Empty vector"]


### PR DESCRIPTION
Close #57 