### PR TITLE
Fix long number parsing in Python package versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ This change log follows the conventions of [keepachangelog.com](http://keepachan
 
 ## [Unreleased]
 
+## [0.33.0] - 2022-06-25
+### Fixed
+- Parsing long numbers in Python versions ((#99)[https://github.com/pilosus/pip-license-checker/issues/99])
+
 ## [0.32.0] - 2022-06-23
 ### Added
 - `lein ancient` to check outdated deps
@@ -267,7 +271,8 @@ weak copyleft types.
 ### Added
 - Structure for Leiningen app project
 
-[Unreleased]: https://github.com/pilosus/pip-license-checker/compare/0.32.0...HEAD
+[Unreleased]: https://github.com/pilosus/pip-license-checker/compare/0.33.0...HEAD
+[0.33.0]: https://github.com/pilosus/pip-license-checker/compare/0.32.0...0.33.0
 [0.32.0]: https://github.com/pilosus/pip-license-checker/compare/0.31.0...0.32.0
 [0.31.0]: https://github.com/pilosus/pip-license-checker/compare/0.30.0...0.31.0
 [0.30.0]: https://github.com/pilosus/pip-license-checker/compare/0.29.0...0.30.0

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject org.clojars.vrs/pip-license-checker "0.32.0"
+(defproject org.clojars.vrs/pip-license-checker "0.33.0-SNAPSHOT"
   :description "License compliance tool to identify dependencies license names and types: permissive, copyleft, proprietory, etc."
   :url "https://github.com/pilosus/pip-license-checker"
   :license {:name "Eclipse Public License 2.0 OR GNU GPL v2+ with Classpath exception"

--- a/src/pip_license_checker/version.clj
+++ b/src/pip_license_checker/version.clj
@@ -24,6 +24,7 @@
 
 ;; Parse version
 
+(def regex-number #"^\d+$")
 (def regex-split-comma #",")
 (def regex-specifier #"(?<op>(===|==|~=|!=|>=|<=|<|>))(?<version>(.*))")
 
@@ -32,7 +33,11 @@
 (defn parse-number
   "Parse number string into integer or return 0"
   [number]
-  (if (not number) 0 (Integer/parseInt number)))
+  (if (or (not number)
+          ;; just to make sure no code execution is possible with read-string
+          (not (re-find #"^-?\d+\.?\d*$" number)))
+    0
+    (read-string number)))
 
 (s/fdef parse-letter-version
   :args (s/cat :letter ::sp/matched-version-part

--- a/test/pip_license_checker/version_test.clj
+++ b/test/pip_license_checker/version_test.clj
@@ -112,7 +112,19 @@
      :post ["post" 345]
      :dev ["dev" 456]
      :local nil}
-    "Release, pre, post and dev version"]])
+    "Release, pre, post and dev version"]
+   ["1.0.dev20160909030348"
+    {:orig "1.0.dev20160909030348"
+     :epoch 0
+     :release [1 0]
+     :pre nil
+     :post nil
+     :dev ["dev" 20160909030348]
+     :local nil}
+    "Make sure long numbers handled correctly"]
+   ["1.0.dev(exploit-run)"
+    nil
+    "Make sure no read-string expoit is possible"]])
 
 (deftest test-parse-version
   (testing "Version parsing"


### PR DESCRIPTION
This is to fix #99 where a checker crashed against `graphql-core==1.0.dev20160909030348`.
`20160909030348` is long that was causing `Integer/parseInt` to fail.