### PR TITLE
Allow pre-release versions for Python native packages in case of  == and === specifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ This change log follows the conventions of [keepachangelog.com](http://keepachan
 
 ## [Unreleased]
 
+## [0.44.0] - 2023-02-25
+
+### Fixed
+- Allow pre-release versions for Python native packages in case of
+  exact equal (`==`) or arbitrary string equal (`===`) specifiers
+  ([#132](https://github.com/pilosus/pip-license-checker/issues/132))
+
 ## [0.43.0] - 2023-02-10
 
 ### Fixed
@@ -406,7 +413,8 @@ weak copyleft types.
 ### Added
 - Structure for Leiningen app project
 
-[Unreleased]: https://github.com/pilosus/pip-license-checker/compare/0.43.0...HEAD
+[Unreleased]: https://github.com/pilosus/pip-license-checker/compare/0.44.0...HEAD
+[0.44.0]: https://github.com/pilosus/pip-license-checker/compare/0.43.0...0.44.0
 [0.43.0]: https://github.com/pilosus/pip-license-checker/compare/0.42.1...0.43.0
 [0.42.1]: https://github.com/pilosus/pip-license-checker/compare/0.42.0...0.42.1
 [0.42.0]: https://github.com/pilosus/pip-license-checker/compare/0.42.0-SNAPSHOT...0.42.0

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject org.pilosus/pip-license-checker "0.43.1-SNAPSHOT"
+(defproject org.pilosus/pip-license-checker "0.44.0"
   :description "License compliance tool to identify dependencies license names and types: permissive, copyleft, proprietory, etc."
   :url "https://github.com/pilosus/pip-license-checker"
   :license {:name "Eclipse Public License 2.0 OR GNU GPL v2+ with Classpath exception"

--- a/test/pip_license_checker/version_test.clj
+++ b/test/pip_license_checker/version_test.clj
@@ -314,7 +314,21 @@
      ["1.48.2" {:yanked false}]]
     false
     ["1.48.0"]
-    "use yanked version for arbitrary-string equal specifier"]])
+    "use yanked version for arbitrary-string equal specifier"]
+   [[["==" "0.0.2a32"]]
+    [["0.0.1" {:yanked false}]
+     ["0.0.2a32" {:yanked false}]
+     ["0.0.3" {:yanked false}]]
+    false
+    ["0.0.2a32"]
+    "use pre-release version for exact equal specifier with --no-pre option"]
+   [[["===" "0.0.2a32"]]
+    [["0.0.1" {:yanked false}]
+     ["0.0.2a32" {:yanked false}]
+     ["0.0.3" {:yanked false}]]
+    false
+    ["0.0.2a32"]
+    "use pre-release version for arbitrary-string equal specifier with --no-pre option"]])
 
 (deftest test-filter-versions
   (testing "Check versions filtering"


### PR DESCRIPTION
Close #132 