### PR TITLE
tech: bump Docker base images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ This change log follows the conventions of [keepachangelog.com](http://keepachan
   `license` field
   ([#152](https://github.com/pilosus/pip-license-checker/issues/152)).
 
+- Dump Docker base images to `eclipse-temurin:21`
+
 
 ## [0.48.0] - 2023-04-28
 
@@ -476,7 +478,8 @@ weak copyleft types.
 ### Added
 - Structure for Leiningen app project
 
-[Unreleased]: https://github.com/pilosus/pip-license-checker/compare/0.48.0...HEAD
+[Unreleased]: https://github.com/pilosus/pip-license-checker/compare/0.49.0...HEA
+[0.49.0]: https://github.com/pilosus/pip-license-checker/compare/0.48.0...0.49.0
 [0.48.0]: https://github.com/pilosus/pip-license-checker/compare/0.47.0...0.48.0
 [0.47.0]: https://github.com/pilosus/pip-license-checker/compare/0.46.1...0.47.0
 [0.46.1]: https://github.com/pilosus/pip-license-checker/compare/0.46.0...0.46.1

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@
 ### Build stage ###
 ###################
 
-FROM clojure:temurin-17-lein-alpine AS build
+FROM clojure:temurin-21-lein-alpine AS build
 
 # Create a working directory
 RUN mkdir -p /usr/src/app
@@ -28,7 +28,7 @@ RUN mv "$(lein uberjar | sed -n 's/^Created \(.*standalone\.jar\)/\1/p')" app.ja
 ### Run stage ###
 #################
 
-FROM eclipse-temurin:17-jre-alpine AS run
+FROM eclipse-temurin:21-jre-alpine AS run
 
 # Create app directory for unpriviledged user
 RUN mkdir -p /usr/src/app


### PR DESCRIPTION
Use `eclipse-temurin:21` images for building and running